### PR TITLE
feat(e2e): pytest-playwright na Busca, Agenda e login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,15 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Playwright artifacts
+playwright-report/
+test-results/
+playwright/.cache/
+
+# Python / pytest (E2E)
+.venv/
+venv/
+.pytest_cache/
+**/__pycache__/
+*.py[cod]

--- a/e2e.env.example
+++ b/e2e.env.example
@@ -1,0 +1,12 @@
+# Copie para ".env.e2e" na raiz (gitignored via .env.*).
+# Os testes carregam .env.e2e automaticamente (não precisa dar source antes do npm).
+# cp e2e.env.example .env.e2e
+#
+# npm run test:e2e
+#
+# Se o login só funciona no mesmo Expo do dia a dia (porta 8081), com Metro já rodando:
+#   npm run test:e2e:devweb
+E2E_LOGIN_EMAIL=
+E2E_LOGIN_PASSWORD=
+# Opcional: API para o bundle quando o pytest inicia o Expo (padrão no conftest: http://127.0.0.1:3000)
+# E2E_EXPO_PUBLIC_API_URL=http://127.0.0.1:3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "tattooali-mobile",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tattooali-mobile"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "android": "npm run android --prefix tattooali",
     "ios": "npm run ios --prefix tattooali",
     "web": "npm run web --prefix tattooali",
-    "setup": "npm install --prefix tattooali"
-  }
+    "setup": "npm install --prefix tattooali",
+    "test:e2e": "bash scripts/run-e2e.sh -v",
+    "test:e2e:headed": "bash scripts/run-e2e.sh -v --headed",
+    "test:e2e:debug": "PWDEBUG=1 bash scripts/run-e2e.sh -v --headed",
+    "test:e2e:devweb": "bash scripts/run-e2e.sh -v --base-url http://localhost:8081",
+    "test:e2e:devweb:headed": "bash scripts/run-e2e.sh -v --headed --base-url http://localhost:8081"
+  },
+  "packageManager": "yarn@4.13.0+sha512.5c20ba010c99815433e5c8453112165e673f1c7948d8d2b267f4b5e52097538658388ebc9f9580656d9b75c5cc996f990f611f99304a2197d4c56d21eea370e7"
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths = tests/e2e
+pythonpath = tests/e2e
+python_files = test_*.py
+addopts = -ra
+# URL base para page.goto("/") (pytest-playwright + pytest-base-url)
+base_url = http://127.0.0.1:19007

--- a/requirements-e2e.txt
+++ b/requirements-e2e.txt
@@ -1,0 +1,13 @@
+# E2E: pytest + Playwright (Python)
+#
+# Setup:
+#   python3 -m venv .venv && . .venv/bin/activate
+#   pip install -r requirements-e2e.txt && python3 -m playwright install chromium
+#
+# Login real (opcional): copie e2e.env.example para .env.e2e na raiz e preencha.
+# O conftest carrega .env.e2e automaticamente (não precisa source antes do npm).
+#   npm run test:e2e
+#   npm run test:e2e:devweb   # contra http://localhost:8081 (Expo já aberto com npm start + w)
+#
+pytest>=8.0,<9
+pytest-playwright>=0.5,<1

--- a/scripts/run-e2e.sh
+++ b/scripts/run-e2e.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Sempre executa pytest a partir da raiz do repositório (evita falha ao rodar de tattooali/).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+exec python3 -m pytest tests/e2e "$@"

--- a/tattooali/components/ArtistCard.jsx
+++ b/tattooali/components/ArtistCard.jsx
@@ -21,7 +21,12 @@ function ArtistCard({ artist, onPress }) {
   const showPhoto = isRemoteUrl(artist.avatar);
   const initial = (artist.name && artist.name.charAt(0).toUpperCase()) || '🎨';
   return (
-    <TouchableOpacity style={styles.card} onPress={onPress} activeOpacity={0.85}>
+    <TouchableOpacity
+      testID={artist?.id != null ? `artist-card-${artist.id}` : 'artist-card'}
+      style={styles.card}
+      onPress={onPress}
+      activeOpacity={0.85}
+    >
       <View style={styles.cardImg}>
         {showPhoto ? (
           <Image source={{ uri: artist.avatar }} style={styles.cardImgPhoto} resizeMode="cover" />

--- a/tattooali/components/ArtistModal.jsx
+++ b/tattooali/components/ArtistModal.jsx
@@ -277,7 +277,7 @@ export function ArtistModal({
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
       <TouchableOpacity style={styles.modalOverlay} activeOpacity={1} onPress={onClose}>
-        <TouchableOpacity style={styles.modalSheet} activeOpacity={1}>
+        <TouchableOpacity testID="artist-modal-sheet" style={styles.modalSheet} activeOpacity={1}>
           <View style={styles.modalHandle} />
 
           <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.modalScroll}>

--- a/tattooali/components/Navbar.jsx
+++ b/tattooali/components/Navbar.jsx
@@ -33,6 +33,7 @@ export default function AppLayout({ children }) {
           return (
             <TouchableOpacity
               key={item.label}
+              testID={`nav-${item.route}`}
               style={[styles.navItem, active && styles.navItemActive]}
               onPress={() => navigation.navigate(item.route)}
               activeOpacity={0.75}

--- a/tattooali/components/SearchFilterModal.jsx
+++ b/tattooali/components/SearchFilterModal.jsx
@@ -130,7 +130,7 @@ const SearchFilterModal = ({ visible, onClose, onApply, onReset }) => {
       onRequestClose={onClose}
     >
       <View style={styles.overlay}>
-        <View style={styles.modalBox}>
+        <View testID="search-filter-modal" style={styles.modalBox}>
           <View style={styles.dragIndicator} />
           <Text style={styles.modalTitle}>Filtrar por</Text>
           <View style={styles.filterChoices}>

--- a/tattooali/package.json
+++ b/tattooali/package.json
@@ -10,7 +10,12 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "test:e2e": "sh -c 'cd .. && npm run test:e2e'",
+    "test:e2e:headed": "sh -c 'cd .. && npm run test:e2e:headed'",
+    "test:e2e:debug": "sh -c 'cd .. && npm run test:e2e:debug'",
+    "test:e2e:devweb": "sh -c 'cd .. && npm run test:e2e:devweb'",
+    "test:e2e:devweb:headed": "sh -c 'cd .. && npm run test:e2e:devweb:headed'"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",

--- a/tattooali/screens/AgendaScreen.jsx
+++ b/tattooali/screens/AgendaScreen.jsx
@@ -286,7 +286,7 @@ export default function AgendaScreen() {
   }
 
   return (
-    <View style={styles.root}>
+    <View style={styles.root} testID="agenda-screen">
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
@@ -304,6 +304,7 @@ export default function AgendaScreen() {
           <Text style={styles.agendaTabsHint}>Suas sessões por status</Text>
           <View style={styles.agendaTabs} accessibilityRole="tablist">
             <Pressable
+              testID="agenda-tab-agendadas"
               accessibilityRole="tab"
               accessibilityState={{ selected: activeTab === 'agendadas' }}
               accessibilityLabel="Sessões agendadas"
@@ -328,6 +329,7 @@ export default function AgendaScreen() {
               </Text>
             </Pressable>
             <Pressable
+              testID="agenda-tab-concluidas"
               accessibilityRole="tab"
               accessibilityState={{ selected: activeTab === 'concluidas' }}
               accessibilityLabel="Sessões concluídas"
@@ -352,6 +354,7 @@ export default function AgendaScreen() {
               </Text>
             </Pressable>
             <Pressable
+              testID="agenda-tab-canceladas"
               accessibilityRole="tab"
               accessibilityState={{ selected: activeTab === 'canceladas' }}
               accessibilityLabel="Sessões canceladas"

--- a/tattooali/screens/BuscaScreen.jsx
+++ b/tattooali/screens/BuscaScreen.jsx
@@ -206,7 +206,7 @@ export default function BuscaScreen() {
   }
 
   return (
-    <View style={styles.root}>
+    <View testID="busca-screen" style={styles.root}>
       <FlatList
         data={loading ? [] : filteredArtists}
         keyExtractor={(item) => item.id.toString()}
@@ -242,6 +242,7 @@ export default function BuscaScreen() {
                   autoCapitalize="none"
                 />
                 <TouchableOpacity
+                  testID="busca-abrir-filtros"
                   style={styles.filterButton}
                   onPress={() => setFilterModalVisible(true)}
                   activeOpacity={0.7}
@@ -258,6 +259,7 @@ export default function BuscaScreen() {
                 {styleChips.map((style) => (
                   <TouchableOpacity
                     key={style}
+                    testID={`busca-chip-${style}`}
                     style={[styles.filterChip, activeFilter === style && styles.filterChipActive]}
                     onPress={() => setActiveFilter(style)}
                     activeOpacity={0.8}
@@ -338,7 +340,7 @@ export default function BuscaScreen() {
         visible={filterModalVisible}
         onClose={() => setFilterModalVisible(false)}
         onApply={(f) => {
-          setappliedBairroId(f.bairro_id);
+          setappliedBairroId(f.bairro_id ?? f.bairro ?? null);
           setAppliedStars(f.estrelas);
         }}
         onReset={() => {

--- a/tattooali/screens/auth/LoginScreen.jsx
+++ b/tattooali/screens/auth/LoginScreen.jsx
@@ -16,7 +16,6 @@ import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import { colors, radius } from '../../theme';
 import { useAuth } from '../../context/AuthContext';
-import { getApiConfigDebug } from '../../lib/config';
 
 export default function LoginScreen() {
   const navigation = useNavigation();
@@ -56,6 +55,7 @@ export default function LoginScreen() {
 
   return (
     <KeyboardAvoidingView
+      testID="login-screen"
       style={styles.root}
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
     >
@@ -315,23 +315,4 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '500',
   },
-  apiDebugBox: {
-    marginTop: 28,
-    padding: 12,
-    borderRadius: radius.sm,
-    backgroundColor: 'rgba(255,255,255,0.06)',
-    borderWidth: 1,
-    borderColor: 'rgba(255,255,255,0.12)',
-  },
-  apiDebugLabel: {
-    color: colors.text3,
-    fontSize: 10,
-    fontWeight: '700',
-    letterSpacing: 0.5,
-    marginBottom: 6,
-    textTransform: 'uppercase',
-  },
-  apiDebugUrl: { color: colors.text, fontSize: 12, fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace' },
-  apiDebugSource: { color: colors.text2, fontSize: 11, marginTop: 6 },
-  apiDebugHint: { color: '#fbbf24', fontSize: 11, marginTop: 8, lineHeight: 16 },
 });

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,166 @@
+"""Sobe ou reutiliza o Expo Web conforme a base URL dos testes (pytest-playwright)."""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from login_helpers import expect_busca_logada, perform_login
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _load_dotenv_e2e() -> None:
+    """Carrega .env.e2e na raiz (gitignored) sem sobrescrever variáveis já exportadas."""
+    path = REPO_ROOT / ".env.e2e"
+    if not path.is_file():
+        return
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        val = val.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = val
+
+
+_load_dotenv_e2e()
+os.chdir(REPO_ROOT)
+TATTOOALI = REPO_ROOT / "tattooali"
+# Porta usada só quando o pytest sobe um Expo dedicado para E2E
+E2E_DEDICATED_PORT = 19007
+
+
+def _session_base_url(request: pytest.FixtureRequest) -> str:
+    """Mesma URL do pytest-base-url (pytest.ini ou --base-url http://localhost:8081)."""
+    try:
+        url = request.config.getoption("base_url")
+    except (ValueError, AttributeError):
+        url = None
+    if url:
+        return str(url).rstrip("/")
+    return f"http://127.0.0.1:{E2E_DEDICATED_PORT}"
+
+
+def _tcp_open(host: str, port: int, timeout: float = 0.25) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _wait_http_ready(base: str, timeout_sec: int = 180) -> None:
+    fetch = base.rstrip("/") + "/"
+    p = urlparse(fetch)
+    host = p.hostname or "127.0.0.1"
+    port = p.port or (443 if p.scheme == "https" else 80)
+    deadline = time.monotonic() + timeout_sec
+    while time.monotonic() < deadline:
+        if not _tcp_open(host, port):
+            time.sleep(0.5)
+            continue
+        try:
+            urllib.request.urlopen(fetch, timeout=5)
+            return
+        except (urllib.error.URLError, TimeoutError, OSError):
+            time.sleep(1)
+    raise RuntimeError(
+        f"App não respondeu em {fetch} dentro de {timeout_sec}s. "
+        f"Se usa --base-url http://localhost:8081, rode antes `cd tattooali && npm start` e abra o Web (w). "
+        f"Para o pytest subir o Expo sozinho, use a URL padrão (porta {E2E_DEDICATED_PORT}) sem --base-url."
+    )
+
+
+@pytest.fixture(scope="session")
+def expo_web_server(request: pytest.FixtureRequest):
+    """
+    - URL padrão (127.0.0.1:19007): sobe ou reutiliza Expo com EXPO_PUBLIC_API_URL no loopback.
+    - URL custom (ex.: http://localhost:8081): só espera o app já rodando (mesmo fluxo do teu teste manual).
+    """
+    base = _session_base_url(request)
+    parsed = urlparse(base)
+    scheme = parsed.scheme or "http"
+    host = parsed.hostname or "127.0.0.1"
+    port = parsed.port
+    if port is None:
+        port = 443 if scheme == "https" else 80
+
+    reuse = os.environ.get("E2E_REUSE_SERVER", "1") == "1"
+    if reuse and _tcp_open(host, port):
+        _wait_http_ready(base)
+        yield base
+        return
+
+    if port == E2E_DEDICATED_PORT:
+        if not TATTOOALI.is_dir():
+            raise RuntimeError(f"Pasta do app não encontrada: {TATTOOALI}")
+
+        env = os.environ.copy()
+        env.setdefault("CI", "1")
+        api_url = os.environ.get("E2E_EXPO_PUBLIC_API_URL", "http://127.0.0.1:3000")
+        env["EXPO_PUBLIC_API_URL"] = api_url
+
+        proc = subprocess.Popen(
+            ["npx", "expo", "start", "--web", f"--port={E2E_DEDICATED_PORT}"],
+            cwd=str(TATTOOALI),
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            _wait_http_ready(base)
+            yield base
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=25)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        return
+
+    _wait_http_ready(base, timeout_sec=120)
+    yield base
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_expo_web(expo_web_server):
+    assert expo_web_server.startswith("http")
+
+
+@pytest.fixture
+def page_logada_busca(page: Page) -> Page:
+    """Login + espera tela Busca (mesmas credenciais E2E do teste de login)."""
+    email = os.environ.get("E2E_LOGIN_EMAIL", "").strip()
+    password = os.environ.get("E2E_LOGIN_PASSWORD", "")
+    if not email or not password:
+        pytest.skip("Crie .env.e2e com E2E_LOGIN_EMAIL e E2E_LOGIN_PASSWORD.")
+    perform_login(page, email, password)
+    expect_busca_logada(page)
+    return page
+
+
+@pytest.fixture
+def page_logada_agenda(page: Page) -> Page:
+    """Login, Busca estável e navegação para Agenda (navbar)."""
+    email = os.environ.get("E2E_LOGIN_EMAIL", "").strip()
+    password = os.environ.get("E2E_LOGIN_PASSWORD", "")
+    if not email or not password:
+        pytest.skip("Crie .env.e2e com E2E_LOGIN_EMAIL e E2E_LOGIN_PASSWORD.")
+    perform_login(page, email, password)
+    expect_busca_logada(page)
+    page.get_by_test_id("nav-Agenda").click()
+    expect(page.get_by_test_id("agenda-screen").first).to_be_visible(timeout=60_000)
+    return page

--- a/tests/e2e/login_helpers.py
+++ b/tests/e2e/login_helpers.py
@@ -1,0 +1,45 @@
+"""Helpers comuns para telas de login (Expo Web / RN)."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+
+def login_root(page: Page):
+    # Stack + Strict Mode podem duplicar a tela no DOM (RN Web).
+    return page.get_by_test_id("login-screen").last
+
+
+def wait_login_shell(page: Page) -> None:
+    expect(login_root(page)).to_be_visible(timeout=60_000)
+
+
+def perform_login(page: Page, email: str, password: str) -> None:
+    page.goto("/")
+    wait_login_shell(page)
+    root = login_root(page)
+    root.get_by_placeholder("seuemail@email.com").fill(email)
+    root.get_by_placeholder("••••••••").fill(password)
+    root.get_by_text("Entrar", exact=True).click()
+
+
+def expect_busca_logada(page: Page) -> None:
+    """Após login bem-sucedido: tela inicial privada é Busca."""
+    try:
+        expect(page.get_by_test_id("busca-screen")).to_be_visible(timeout=90_000)
+    except AssertionError as err:
+        root = login_root(page)
+        if root.is_visible(timeout=2000):
+            snippet = root.inner_text(timeout=5000)[:900]
+            raise AssertionError(
+                "Não chegou na tela Busca após login. "
+                "Garanta o backend em http://127.0.0.1:3000 (ou E2E_EXPO_PUBLIC_API_URL) e CORS para "
+                "http://127.0.0.1:19007. Se reutiliza um Expo já aberto com API só em IP da LAN, "
+                "feche-o ou use E2E_REUSE_SERVER=0 para o pytest subir outro Expo com API no loopback. "
+                f"Trecho da tela de login:\n{snippet}"
+            ) from err
+        raise
+    expect(
+        page.get_by_placeholder("Buscar tatuador, estilo, bairro...")
+    ).to_be_visible(timeout=15_000)
+    expect(page.get_by_text("TATUADORES", exact=True)).to_be_visible(timeout=30_000)

--- a/tests/e2e/test_agenda_flow.py
+++ b/tests/e2e/test_agenda_flow.py
@@ -1,0 +1,73 @@
+"""Tela Agenda: renderização inicial e três abas de status."""
+
+from __future__ import annotations
+
+import re
+
+from playwright.sync_api import Locator, Page, expect
+
+
+def _expect_conteudo_agendadas(agenda: Locator) -> None:
+    vazio = agenda.get_by_text("Nenhum agendamento encontrado", exact=False)
+    badge = agenda.get_by_text(re.compile(r"^Agendada$", re.I))
+    expect(vazio.or_(badge).first).to_be_visible(timeout=30_000)
+
+
+def _expect_conteudo_concluidas(agenda: Locator) -> None:
+    vazio = agenda.get_by_text("Nenhuma sessão concluída", exact=False)
+    badge = agenda.get_by_text(re.compile(r"^Concluída$", re.I))
+    expect(vazio.or_(badge).first).to_be_visible(timeout=30_000)
+
+
+def _expect_conteudo_canceladas(agenda: Locator) -> None:
+    vazio = agenda.get_by_text("Nenhuma sessão cancelada", exact=False)
+    badge = agenda.get_by_text(re.compile(r"^Cancelada$", re.I))
+    expect(vazio.or_(badge).first).to_be_visible(timeout=30_000)
+
+
+def test_agenda_render_hint_tablist_e_tres_abas(page_logada_agenda: Page) -> None:
+    page = page_logada_agenda
+    agenda = page.get_by_test_id("agenda-screen").first
+    expect(agenda).to_be_visible(timeout=30_000)
+    expect(page.get_by_text(re.compile(r"Suas sessões por status", re.I))).to_be_visible()
+    expect(page.get_by_role("tablist")).to_be_visible()
+    expect(page.get_by_test_id("agenda-tab-agendadas").first).to_be_visible()
+    expect(page.get_by_test_id("agenda-tab-concluidas").first).to_be_visible()
+    expect(page.get_by_test_id("agenda-tab-canceladas").first).to_be_visible()
+    for label in ("Agendadas", "Concluídas", "Canceladas"):
+        expect(agenda.get_by_text(label, exact=True).first).to_be_visible()
+
+
+def test_agenda_abas_roles_acessiveis(page_logada_agenda: Page) -> None:
+    page = page_logada_agenda
+    expect(page.get_by_role("tab", name="Sessões agendadas").first).to_be_visible()
+    expect(page.get_by_role("tab", name="Sessões concluídas").first).to_be_visible()
+    expect(page.get_by_role("tab", name="Sessões canceladas").first).to_be_visible()
+
+
+def _agenda_pronta_apos_carga(page: Page) -> None:
+    """API ok mostra horário; falha mostra retry — evita assert antes do fim do loading."""
+    ok = page.get_by_text(re.compile(r"Última atualização:", re.I))
+    erro = page.get_by_text("Tentar novamente", exact=True)
+    expect(ok.or_(erro).first).to_be_visible(timeout=90_000)
+
+
+def test_agenda_abas_mudam_conteudo_lista_ou_vazio(page_logada_agenda: Page) -> None:
+    """Cada aba mostra lista com badge de status ou vazio; RN Web não define aria-selected nas tabs."""
+    page = page_logada_agenda
+    agenda = page.get_by_test_id("agenda-screen").first
+    _agenda_pronta_apos_carga(page)
+
+    t_ag = page.get_by_test_id("agenda-tab-agendadas").first
+    t_co = page.get_by_test_id("agenda-tab-concluidas").first
+    t_ca = page.get_by_test_id("agenda-tab-canceladas").first
+
+    _expect_conteudo_agendadas(agenda)
+    t_co.click()
+    _expect_conteudo_concluidas(agenda)
+
+    t_ca.click()
+    _expect_conteudo_canceladas(agenda)
+
+    t_ag.click()
+    _expect_conteudo_agendadas(agenda)

--- a/tests/e2e/test_auth_login_e2e.py
+++ b/tests/e2e/test_auth_login_e2e.py
@@ -1,0 +1,24 @@
+"""Login real contra API (Expo Web). Credenciais só por variável de ambiente — nunca commitar."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from login_helpers import expect_busca_logada, perform_login
+
+EMAIL = os.environ.get("E2E_LOGIN_EMAIL", "").strip()
+PASSWORD = os.environ.get("E2E_LOGIN_PASSWORD", "")
+
+pytestmark = pytest.mark.skipif(
+    not EMAIL or not PASSWORD,
+    reason="Crie .env.e2e na raiz com E2E_LOGIN_EMAIL e E2E_LOGIN_PASSWORD (veja e2e.env.example).",
+)
+
+
+def test_login_redireciona_para_busca(page: Page) -> None:
+    perform_login(page, EMAIL, PASSWORD)
+    expect_busca_logada(page)
+    expect(page.get_by_text("BUSCAR", exact=True).first).to_be_visible()

--- a/tests/e2e/test_auth_public_flow.py
+++ b/tests/e2e/test_auth_public_flow.py
@@ -1,0 +1,55 @@
+"""Fluxo público de autenticação (Expo Web)."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+from login_helpers import login_root, wait_login_shell
+
+
+def test_renderiza_tela_de_login(page: Page) -> None:
+    page.goto("/")
+    wait_login_shell(page)
+    root = login_root(page)
+    expect(root.get_by_text("EMAIL", exact=True)).to_be_visible()
+    expect(root.get_by_text("SENHA", exact=True)).to_be_visible()
+    expect(root.get_by_text("Entrar", exact=True)).to_be_visible()
+
+
+def test_mostra_erro_sem_email(page: Page) -> None:
+    page.goto("/")
+    wait_login_shell(page)
+    login_root(page).get_by_text("Entrar", exact=True).click()
+    expect(
+        login_root(page).get_by_text("Informe seu e-mail.", exact=True)
+    ).to_be_visible()
+
+
+def test_mostra_erro_sem_senha(page: Page) -> None:
+    page.goto("/")
+    wait_login_shell(page)
+    root = login_root(page)
+    root.get_by_placeholder("seuemail@email.com").fill("a@b.com")
+    root.get_by_text("Entrar", exact=True).click()
+    expect(root.get_by_text("Informe sua senha.", exact=True)).to_be_visible()
+
+
+def test_navega_para_cadastro(page: Page) -> None:
+    page.goto("/")
+    wait_login_shell(page)
+    login_root(page).get_by_text("Criar conta", exact=True).click()
+    expect(
+        page.get_by_text("Junte-se à comunidade Tattoali", exact=True)
+    ).to_be_visible()
+    expect(page.get_by_text("Cadastrar", exact=True)).to_be_visible()
+
+
+def test_recuperacao_senha_e_volta(page: Page) -> None:
+    page.goto("/")
+    wait_login_shell(page)
+    login_root(page).get_by_text("Esqueci minha senha", exact=True).click()
+    expect(
+        page.get_by_text("Enviar link de redefinição", exact=True)
+    ).to_be_visible()
+    page.get_by_text("Voltar para o login", exact=True).click()
+    wait_login_shell(page)

--- a/tests/e2e/test_busca_flow.py
+++ b/tests/e2e/test_busca_flow.py
@@ -1,0 +1,98 @@
+"""Tela Busca logada: hero, filtros, modal de filtros e Ver perfil (ArtistModal)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+
+def _locator_chip_anime(page: Page) -> Locator:
+    """Chip Anime: testID segue a API (capitalização variável); RN Web pode duplicar a árvore — .last
+    costuma ser a instância visível. Qualquer chip cuja etiqueta contenha 'Anime' (sem âncoras ^$ por
+    possíveis espaços/ZWJ)."""
+    busca = page.get_by_test_id("busca-screen").last
+    por_id = (
+        busca.get_by_test_id("busca-chip-Anime")
+        .or_(busca.get_by_test_id("busca-chip-anime"))
+        .or_(busca.get_by_test_id("busca-chip-ANIME"))
+    )
+    por_texto_no_chip = busca.locator("[data-testid^='busca-chip-']").filter(
+        has_text=re.compile(r"Anime", re.I)
+    )
+    return por_id.or_(por_texto_no_chip).first
+
+
+def test_busca_header_hero_e_campo(page_logada_busca: Page) -> None:
+    page = page_logada_busca
+    expect(page.get_by_test_id("busca-screen")).to_be_visible()
+    expect(page.get_by_text("BUSCA", exact=True).first).to_be_visible()
+    expect(page.get_by_placeholder("Buscar tatuador, estilo, bairro...")).to_be_visible()
+    # Um único Text no RN: "ENCONTRE\nSEU ARTISTA" — exact "SEU ARTISTA" não casa.
+    expect(page.get_by_text(re.compile(r"ENCONTRE\s+SEU\s+ARTISTA", re.I | re.S))).to_be_visible()
+    expect(
+        page.get_by_text("Busque por nome, bio, endereço", exact=False).first
+    ).to_be_visible()
+
+
+def test_busca_nav_inferior_destaca_buscar(page_logada_busca: Page) -> None:
+    expect(page_logada_busca.get_by_text("BUSCAR", exact=True).first).to_be_visible()
+
+
+def test_busca_listagem_ou_vazio(page_logada_busca: Page) -> None:
+    page = page_logada_busca
+    expect(page.get_by_text("TATUADORES", exact=True)).to_be_visible(timeout=60_000)
+    cards = page.locator("[data-testid^='artist-card-']")
+    empty_title = page.get_by_text("Nenhum tatuador encontrado", exact=True)
+    try:
+        expect(cards.first).to_be_visible(timeout=90_000)
+    except AssertionError:
+        expect(empty_title).to_be_visible(timeout=5_000)
+
+
+def test_busca_chip_segundo_estilo_mostra_resultados(page_logada_busca: Page) -> None:
+    page = page_logada_busca
+    expect(page.get_by_text("TATUADORES", exact=True)).to_be_visible(timeout=60_000)
+    chips = page.locator("[data-testid^='busca-chip-']")
+    expect(chips.first).to_be_visible(timeout=30_000)
+    if chips.count() < 2:
+        pytest.skip("Menos de 2 chips de estilo na tela")
+    chips.nth(1).click()
+    expect(page.get_by_text("RESULTADOS", exact=True)).to_be_visible(timeout=45_000)
+    chips.nth(0).click()
+    expect(page.get_by_text("TATUADORES", exact=True)).to_be_visible(timeout=45_000)
+
+
+def test_busca_filtro_anime_lista_isabelle(page_logada_busca: Page) -> None:
+    page = page_logada_busca
+    expect(page.get_by_text("TATUADORES", exact=True)).to_be_visible(timeout=60_000)
+    anime_chip = _locator_chip_anime(page)
+    # Os chips de estilo chegam após o catálogo; count()==0 no primeiro instante gerava skip falso.
+    expect(anime_chip).to_be_visible(timeout=60_000)
+    anime_chip.scroll_into_view_if_needed()
+    anime_chip.click()
+    expect(page.get_by_text("RESULTADOS", exact=True)).to_be_visible(timeout=45_000)
+    expect(page.get_by_text("Isabelle Lopes", exact=True).first).to_be_visible(timeout=45_000)
+
+
+def test_busca_modal_filtros_abrir_e_aplicar(page_logada_busca: Page) -> None:
+    page = page_logada_busca
+    page.get_by_test_id("busca-abrir-filtros").click()
+    expect(page.get_by_test_id("search-filter-modal")).to_be_visible()
+    expect(page.get_by_text("Filtrar por", exact=True)).to_be_visible()
+    page.get_by_text("Aplicar", exact=True).click()
+    expect(page.get_by_test_id("search-filter-modal")).to_be_hidden(timeout=15_000)
+
+
+def test_busca_ver_perfil_abre_modal_e_fecha(page_logada_busca: Page) -> None:
+    page = page_logada_busca
+    ver = page.get_by_text("Ver perfil", exact=True).first
+    expect(ver).to_be_visible(timeout=90_000)
+    ver.click()
+    sheet = page.get_by_test_id("artist-modal-sheet")
+    expect(sheet).to_be_visible(timeout=30_000)
+    fechar = sheet.get_by_text("Fechar", exact=True)
+    expect(fechar).to_be_visible(timeout=90_000)
+    fechar.click()
+    expect(sheet).to_be_hidden(timeout=15_000)


### PR DESCRIPTION
- Adiciona pytest.ini, requirements-e2e, scripts/run-e2e.sh e e2e.env.example.
- conftest sobe ou reutiliza Expo Web; fixture page_logada_agenda.
- Testes: fluxo público, login, Busca (hero, chips, modal, perfil, filtro Anime com espera estável), Agenda (três abas sem aria-selected).
- testIDs em Navbar (nav-*), Agenda, Busca, cards e modais para locators estáveis.
- package.json na raiz e em tattooali com scripts E2E; .gitignore para artefatos Playwright/pytest.