### PR TITLE
feat(e2e): testes Playwright para Perfil, Contatos e Chat

### DIFF
--- a/tattooali/navigation/PrivateNavigator.jsx
+++ b/tattooali/navigation/PrivateNavigator.jsx
@@ -94,7 +94,25 @@ export default function PrivateNavigator() {
       <Stack.Screen
         name="EditarPerfil"
         component={EditarPerfilScreen}
-        options={{ headerBackTitleVisible: false }}
+        options={({ navigation }) => ({
+          headerBackTitleVisible: false,
+          headerLeft: () => (
+            <TouchableOpacity
+              testID="editar-perfil-header-back"
+              onPress={() => navigation.goBack()}
+              style={{
+                width: 44,
+                height: 44,
+                alignItems: 'center',
+                justifyContent: 'center',
+                marginLeft: 4,
+              }}
+              activeOpacity={0.7}
+            >
+              <Ionicons name="chevron-back" size={28} color="#f0f0f0" />
+            </TouchableOpacity>
+          ),
+        })}
       />
       <Stack.Screen name="Contatos"       component={Contactsscreen}       />
       <Stack.Screen 

--- a/tattooali/screens/ChatScreen.jsx
+++ b/tattooali/screens/ChatScreen.jsx
@@ -204,13 +204,13 @@ export default function ChatScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <SafeAreaView testID="chat-screen" style={styles.safeArea}>
       <KeyboardAvoidingView
         style={styles.container}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
         <View style={styles.header}>
-          <TouchableOpacity onPress={() => navigation.goBack()} style={styles.backButton}>
+          <TouchableOpacity testID="chat-back" onPress={() => navigation.goBack()} style={styles.backButton}>
             <Ionicons name="chevron-back" size={28} color="#f0f0f0" />
           </TouchableOpacity>
 
@@ -255,6 +255,7 @@ export default function ChatScreen() {
 
         <View style={styles.inputContainer}>
           <TextInput
+            testID="chat-input"
             style={styles.input}
             placeholder="Digite sua mensagem..."
             placeholderTextColor="#555"
@@ -264,6 +265,7 @@ export default function ChatScreen() {
             editable={!!conversationId && !error}
           />
           <TouchableOpacity
+            testID="chat-send"
             style={[styles.sendButton, (inputText.trim().length === 0 || !conversationId) && { opacity: 0.5 }]}
             onPress={handleSend}
             disabled={inputText.trim().length === 0 || !conversationId}

--- a/tattooali/screens/Contactsscreen.jsx
+++ b/tattooali/screens/Contactsscreen.jsx
@@ -24,6 +24,7 @@ const ContactItem = React.memo(({ item, onPress }) => {
 
   return (
     <TouchableOpacity
+      testID={`contatos-conversa-${item.id}`}
       style={styles.contactItem}
       onPress={() => onPress(item)}
       activeOpacity={0.7}
@@ -110,7 +111,7 @@ export default function ContactsScreen({ navigation }) {
 
   return (
     <AppLayout>
-      <SafeAreaView style={styles.safe}>
+      <SafeAreaView testID="contatos-screen" style={styles.safe}>
         <StatusBar barStyle="light-content" backgroundColor={C.ink} />
 
       {/* ── HEADER ─────────────────────────────────────────── */}

--- a/tattooali/screens/EditarPerfilScreen.jsx
+++ b/tattooali/screens/EditarPerfilScreen.jsx
@@ -357,7 +357,7 @@ export default function EditarPerfilScreen() {
   }
 
   return (
-    <View style={styles.root}>
+    <View testID="editar-perfil-screen" style={styles.root}>
       <ScrollView
         ref={scrollRef}
         contentContainerStyle={styles.scrollContent}

--- a/tattooali/screens/PerfilScreen.jsx
+++ b/tattooali/screens/PerfilScreen.jsx
@@ -98,7 +98,7 @@ export default function PerfilScreen({ route }) {
   }, [route?.params?.profile, user]);
 
   return (
-    <View style={styles.root}>
+    <View testID="perfil-screen" style={styles.root}>
       <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
@@ -140,6 +140,7 @@ export default function PerfilScreen({ route }) {
             </View>
           </View>
           <TouchableOpacity
+            testID="perfil-editar"
             style={styles.btnOutline}
             onPress={() => navigation.navigate('EditarPerfil', { profile })}
           >

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -164,3 +164,31 @@ def page_logada_agenda(page: Page) -> Page:
     page.get_by_test_id("nav-Agenda").click()
     expect(page.get_by_test_id("agenda-screen").first).to_be_visible(timeout=60_000)
     return page
+
+
+@pytest.fixture
+def page_logada_perfil(page: Page) -> Page:
+    """Login, Busca e navbar Perfil."""
+    email = os.environ.get("E2E_LOGIN_EMAIL", "").strip()
+    password = os.environ.get("E2E_LOGIN_PASSWORD", "")
+    if not email or not password:
+        pytest.skip("Crie .env.e2e com E2E_LOGIN_EMAIL e E2E_LOGIN_PASSWORD.")
+    perform_login(page, email, password)
+    expect_busca_logada(page)
+    page.get_by_test_id("nav-Perfil").click()
+    expect(page.get_by_test_id("perfil-screen").first).to_be_visible(timeout=60_000)
+    return page
+
+
+@pytest.fixture
+def page_logada_contatos(page: Page) -> Page:
+    """Login, Busca e navbar Contatos (lista de conversas)."""
+    email = os.environ.get("E2E_LOGIN_EMAIL", "").strip()
+    password = os.environ.get("E2E_LOGIN_PASSWORD", "")
+    if not email or not password:
+        pytest.skip("Crie .env.e2e com E2E_LOGIN_EMAIL e E2E_LOGIN_PASSWORD.")
+    perform_login(page, email, password)
+    expect_busca_logada(page)
+    page.get_by_test_id("nav-Contatos").click()
+    expect(page.get_by_test_id("contatos-screen").first).to_be_visible(timeout=60_000)
+    return page

--- a/tests/e2e/test_chat_flow.py
+++ b/tests/e2e/test_chat_flow.py
@@ -1,0 +1,47 @@
+"""Contatos (lista de chats) e tela Chat quando acessível pelo modal na Busca."""
+
+from __future__ import annotations
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+def test_contatos_render_mensagens_vazio_ou_lista(page_logada_contatos: Page) -> None:
+    page = page_logada_contatos
+    expect(page.get_by_text("CONTATOS", exact=True).first).to_be_visible(timeout=30_000)
+    root = page.get_by_test_id("contatos-screen").first
+    expect(root).to_be_visible()
+    expect(root.get_by_text("Mensagens", exact=True)).to_be_visible()
+    subt = root.get_by_text(
+        "Converse com seus tatuadores", exact=False
+    ).or_(root.get_by_text("Converse com seus clientes", exact=False))
+    expect(subt.first).to_be_visible(timeout=15_000)
+    vazio = root.get_by_text("Nenhuma conversa ainda", exact=False)
+    carregando = root.get_by_text("Carregando", exact=False)
+    config = root.get_by_text("EXPO_PUBLIC_SUPABASE", exact=False)
+    linhas = page.locator("[data-testid^='contatos-conversa-']")
+    expect(vazio.or_(carregando).or_(config).or_(linhas.first)).to_be_visible(timeout=60_000)
+
+
+def test_chat_abre_pelo_modal_conversar(page_logada_busca: Page) -> None:
+    """Busca → Ver perfil → Conversar (se o card tiver user_id após detalhe)."""
+    page = page_logada_busca
+    expect(page.get_by_test_id("busca-screen").first).to_be_visible(timeout=15_000)
+    ver = page.get_by_text("Ver perfil", exact=True).first
+    expect(ver).to_be_visible(timeout=90_000)
+    ver.click()
+    sheet = page.get_by_test_id("artist-modal-sheet")
+    expect(sheet).to_be_visible(timeout=30_000)
+    conv = sheet.get_by_text("Conversar", exact=True)
+    try:
+        expect(conv).to_be_visible(timeout=45_000)
+    except AssertionError:
+        sheet.get_by_text("Fechar", exact=True).click()
+        pytest.skip("Sem botão Conversar (perfil sem user_id ou ainda a carregar detalhe)")
+    conv.click()
+    chat = page.get_by_test_id("chat-screen").first
+    expect(chat).to_be_visible(timeout=30_000)
+    expect(page.get_by_test_id("chat-input").first).to_be_visible(timeout=20_000)
+    expect(page.get_by_test_id("chat-send").first).to_be_visible()
+    page.get_by_test_id("chat-back").first.click()
+    expect(page.get_by_test_id("busca-screen").first).to_be_visible(timeout=20_000)

--- a/tests/e2e/test_perfil_flow.py
+++ b/tests/e2e/test_perfil_flow.py
@@ -1,0 +1,26 @@
+"""Tela Perfil logada: hero, lista de atalhos e fluxo Editar perfil."""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+
+def test_perfil_cabecalho_stack_e_conteudo(page_logada_perfil: Page) -> None:
+    page = page_logada_perfil
+    expect(page.get_by_text("MEU PERFIL", exact=True).first).to_be_visible(timeout=30_000)
+    perfil = page.get_by_test_id("perfil-screen").first
+    expect(perfil).to_be_visible()
+    expect(perfil.get_by_text("Editar perfil", exact=True)).to_be_visible(timeout=15_000)
+    expect(perfil.get_by_text("Minha Agenda", exact=True)).to_be_visible()
+    expect(perfil.get_by_text("Mensagens", exact=True)).to_be_visible()
+    expect(perfil.get_by_text("Minhas Avaliações", exact=True)).to_be_visible()
+
+
+def test_perfil_abrir_editar_e_voltar(page_logada_perfil: Page) -> None:
+    page = page_logada_perfil
+    page.get_by_test_id("perfil-screen").first.get_by_test_id("perfil-editar").click()
+    expect(page.get_by_test_id("editar-perfil-screen").first).to_be_visible(timeout=30_000)
+    expect(page.get_by_text("EDITAR PERFIL", exact=True).first).to_be_visible(timeout=15_000)
+    expect(page.get_by_text("Informações pessoais", exact=True).first).to_be_visible(timeout=15_000)
+    page.get_by_test_id("editar-perfil-header-back").first.click()
+    expect(page.get_by_test_id("perfil-screen").first).to_be_visible(timeout=30_000)


### PR DESCRIPTION
Novos ficheiros e fixtures pytest-playwright (conftest: page_logada_perfil, page_logada_contatos).

Testes em tests/e2e/test_perfil_flow.py:
- test_perfil_cabecalho_stack_e_conteudo
- test_perfil_abrir_editar_e_voltar

Testes em tests/e2e/test_chat_flow.py:
- test_contatos_render_mensagens_vazio_ou_lista
- test_chat_abre_pelo_modal_conversar

App: testIDs em Perfil, Contatos, Chat; header voltar em EditarPerfil (editar-perfil-header-back) para E2E alinhado ao stack RN.